### PR TITLE
feat: Support set image operation for sidecarsets

### DIFF
--- a/pkg/cmd/set/set_image.go
+++ b/pkg/cmd/set/set_image.go
@@ -244,8 +244,8 @@ func (o *SetImageOptions) Run() error {
 				var initContainerFound, containerFound bool
 				// Check if the type is kruiseappsv1alpha1.SidecarSet, and if the placeholder is nil.
 				if t, ok := obj.(*kruiseappsv1alpha1.SidecarSet); ok && spec == nil {
-					initContainerFound = setSideCarImage(t.Spec.Containers, name, resolvedImageName)
-					containerFound = setSideCarImage(t.Spec.InitContainers, name, resolvedImageName)
+					initContainerFound = setSideCarImage(t.Spec.InitContainers, name, resolvedImageName)
+					containerFound = setSideCarImage(t.Spec.Containers, name, resolvedImageName)
 				} else {
 					initContainerFound = setImage(spec.InitContainers, name, resolvedImageName)
 					containerFound = setImage(spec.Containers, name, resolvedImageName)

--- a/pkg/cmd/set/set_image.go
+++ b/pkg/cmd/set/set_image.go
@@ -19,6 +19,7 @@ package set
 import (
 	"fmt"
 
+	kruiseappsv1alpha1 "github.com/openkruise/kruise-api/apps/v1alpha1"
 	"github.com/openkruise/kruise-tools/pkg/internal/polymorphichelpers"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -240,9 +241,15 @@ func (o *SetImageOptions) Run() error {
 					}
 					continue
 				}
-
-				initContainerFound := setImage(spec.InitContainers, name, resolvedImageName)
-				containerFound := setImage(spec.Containers, name, resolvedImageName)
+				var initContainerFound, containerFound bool
+				// Check if the type is kruiseappsv1alpha1.SidecarSet, and if the placeholder is nil.
+				if t, ok := obj.(*kruiseappsv1alpha1.SidecarSet); ok && spec == nil {
+					initContainerFound = setSideCarImage(t.Spec.Containers, name, resolvedImageName)
+					containerFound = setSideCarImage(t.Spec.InitContainers, name, resolvedImageName)
+				} else {
+					initContainerFound = setImage(spec.InitContainers, name, resolvedImageName)
+					containerFound = setImage(spec.Containers, name, resolvedImageName)
+				}
 				if !containerFound && !initContainerFound {
 					allErrs = append(allErrs, fmt.Errorf("error: unable to find container named %q", name))
 				}
@@ -305,6 +312,19 @@ func (o *SetImageOptions) Run() error {
 }
 
 func setImage(containers []corev1.Container, containerName string, image string) bool {
+	containerFound := false
+	// Find the container to update, and update its image
+	for i, c := range containers {
+		if c.Name == containerName || containerName == "*" {
+			containerFound = true
+			containers[i].Image = image
+		}
+	}
+	return containerFound
+}
+
+// setSideCarImage
+func setSideCarImage(containers []kruiseappsv1alpha1.SidecarContainer, containerName string, image string) bool {
 	containerFound := false
 	// Find the container to update, and update its image
 	for i, c := range containers {

--- a/pkg/cmd/set/set_image_test.go
+++ b/pkg/cmd/set/set_image_test.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"testing"
 
+	kruiseappsv1alpha1 "github.com/openkruise/kruise-api/apps/v1alpha1"
+
 	"github.com/stretchr/testify/assert"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -611,6 +613,22 @@ func TestSetImageRemote(t *testing.T) {
 			groupVersion: corev1.SchemeGroupVersion,
 			path:         "/namespaces/test/replicationcontrollers/nginx",
 			args:         []string{"replicationcontroller", "nginx", "*=thingy"},
+		},
+		{
+			name: "set image kruiseappsv1alpha1.SidecarSet",
+			object: &kruiseappsv1alpha1.SidecarSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
+				Spec: kruiseappsv1alpha1.SidecarSetSpec{
+					Containers: []kruiseappsv1alpha1.SidecarContainer{
+						{
+							Container: corev1.Container{Name: "nginx", Image: "nginx"},
+						},
+					},
+				},
+			},
+			groupVersion: corev1.SchemeGroupVersion,
+			path:         "/namespaces/test/sidecarsets/nginx",
+			args:         []string{"sidecarsets", "nginx", "*=thingy"},
 		},
 	}
 	for _, input := range inputs {

--- a/pkg/internal/polymorphichelpers/updatepodspec.go
+++ b/pkg/internal/polymorphichelpers/updatepodspec.go
@@ -40,6 +40,12 @@ func updatePodSpecForObject(obj runtime.Object, fn func(*v1.PodSpec) error) (boo
 		return true, fn(&t.Spec.Template.Spec)
 	case *kruiseappsv1alpha1.DaemonSet:
 		return true, fn(&t.Spec.Template.Spec)
+	case *kruiseappsv1alpha1.SidecarSet:
+		// Because the fn function requires passing v1.PodSpec as a parameter,
+		// but kruiseappsv1alpha1.SidecarSet only has kruiseappsv1alpha1.SidecarContainer,
+		// and their types do not match.
+		// Therefore, passing nil as a placeholder here.
+		return true, fn(nil)
 	case *v1.Pod:
 		return true, fn(&t.Spec)
 		// ReplicationController


### PR DESCRIPTION
### Result
User can use `kubectl kruise set image sidecarsets/test-sidecarset sidecar1=debian:11`

### Fix Issue
Fix: https://github.com/openkruise/kruise/issues/1106

### Change
- pkg/internal/polymorphichelpers/updatepodspec.go: Add a `kruiseappsv1alpha1.SidecarSet` branch.
- pkg/cmd/set/set_image.go: Check if it is `kruiseappsv1alpha1.SidecarSet` type then use `setSideCarImage` function which is similar with `setImage`.
- pkg/cmd/set/set_image_test.go: Add unit test
