### PR TITLE
Update k8s registry references

### DIFF
--- a/testdata/set/multi-resource-yaml.yaml
+++ b/testdata/set/multi-resource-yaml.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: k8s.gcr.io/pause:3.2
+        image: registry.k8s.io/pause:3.2
 ---
 apiVersion: v1
 kind: ReplicationController
@@ -30,4 +30,4 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: k8s.gcr.io/pause:3.2
+        image: registry.k8s.io/pause:3.2

--- a/testdata/set/namespaced-resource.yaml
+++ b/testdata/set/namespaced-resource.yaml
@@ -14,4 +14,4 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: k8s.gcr.io/pause:3.2
+        image: registry.k8s.io/pause:3.2


### PR DESCRIPTION
Per https://github.com/kubernetes/k8s.io/issues/4780, Kubernetes is migrating its image registry to registry.k8s.io, and this repository is impacted.

We have to update the references of k8s.gcr.io to registry.k8s.io by April 3rd to remain up-to-date.

Here's a quick search for k8s.gcr.io on this repo. [[search result]](https://github.com/search?q=org%3Adapr%20%22k8s.gcr.io%22&type=code). Note that there may be other valid references (like, in the form of generated code, etc) which we have to be aware of.