### PR TITLE
集成kruise rollout对象的undo功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,10 @@ $ kubectl kruise rollout status statefulsets/sts1
 $ kubectl kruise rollout status statefulsets.apps.kruise.io/sts2
 
 # approve a kruise rollout resource named "rollout-demo" in "ns-demo" namespace
-$ kubectl-kruise rollout approve rollout-demo -n ns-demo`
+$ kubectl kruise rollout approve rollout-demo -n ns-demo`
+
+# undo a kruise rollout resource
+$ kubectl kruise rollout undo rollout/rollout-demo
 ```
 
 ### set
@@ -138,7 +141,7 @@ kubectl kruise exec clone/myclone -S sidecar-container -it -- bash
 ```bash
 kubectl kruise migrate CloneSet --from Deployment --src-name deployment-demo --dst-name cloneset-demo --create --copy
 ```
-   
+
 #### kubectl kruise rollout for CloneSet workload
    * [x] undo
    * [x] history
@@ -146,7 +149,7 @@ kubectl kruise migrate CloneSet --from Deployment --src-name deployment-demo --d
    * [x] pause
    * [x] resume
    * [x] restart
-   
+
 #### kubectl kruise rollout for Advanced StatefulSet
    * [x]  undo
    * [x] history
@@ -155,22 +158,22 @@ kubectl kruise migrate CloneSet --from Deployment --src-name deployment-demo --d
 
 #### kubectl kruise expose for CloneSet workload
    * [x] kubectl kruise expose cloneset demo-clone  --port=80 --target-port=8000
-   
+
 #### kubectl kruise set SUBCOMMAND [options] for CloneSet
    * [x] kubectl kruise set image cloneset/abc
    * [x] kubectl kruise set env cloneset/abc
    * [x] kubectl kruise set serviceaccount cloneset/abc
    * [x] kubectl kruise set resources cloneset/abc
-   
+
 #### kubectl kruise set SUBCOMMAND [options] for Advanced StatefulSet
    * [x] kubectl kruise set image asts/abc
    * [x] kubectl kruise set env asts/abc
    * [x] kubectl kruise set serviceaccount asts/abc
    * [x] kubectl kruise set resources asts/abc
-   
+
 #### kubectl kruise autoscale SUBCOMMAND [options]
    * [ ] kubectl kruise autoscale 
- 
+
 
 ### Contributing
 We encourage you to help out by reporting issues, improving documentation, fixing bugs, or adding new features. 

--- a/pkg/internal/apps/kind_visitor.go
+++ b/pkg/internal/apps/kind_visitor.go
@@ -37,6 +37,7 @@ type KindVisitor interface {
 	VisitCloneSet(kind GroupKindElement)
 	VisitAdvancedStatefulSet(kind GroupKindElement)
 	VisitAdvancedDaemonSet(kind GroupKindElement)
+	VisitRollout(kind GroupKindElement)
 }
 
 // GroupKindElement defines a Kubernetes API group elem
@@ -67,6 +68,8 @@ func (elem GroupKindElement) Accept(visitor KindVisitor) error {
 		visitor.VisitAdvancedStatefulSet(elem)
 	case elem.GroupMatch("apps.kruise.io") && elem.Kind == "DaemonSet":
 		visitor.VisitAdvancedDaemonSet(elem)
+	case elem.GroupMatch("rollouts.kruise.io") && elem.Kind == "Rollout":
+		visitor.VisitRollout(elem)
 	default:
 		return fmt.Errorf("no visitor method exists for %v", elem)
 	}

--- a/pkg/internal/polymorphichelpers/history.go
+++ b/pkg/internal/polymorphichelpers/history.go
@@ -79,6 +79,7 @@ func (v *HistoryVisitor) VisitPod(kind internalapps.GroupKindElement)           
 func (v *HistoryVisitor) VisitReplicaSet(kind internalapps.GroupKindElement)            {}
 func (v *HistoryVisitor) VisitReplicationController(kind internalapps.GroupKindElement) {}
 func (v *HistoryVisitor) VisitCronJob(kind internalapps.GroupKindElement)               {}
+func (v *HistoryVisitor) VisitRollout(kind internalapps.GroupKindElement)               {}
 
 // HistoryViewerFor returns an implementation of HistoryViewer interface for the given schema kind
 func HistoryViewerFor(kind schema.GroupKind, c kubernetes.Interface, kc kruiseclientsets.Interface) (HistoryViewer, error) {

--- a/pkg/internal/polymorphichelpers/rollback.go
+++ b/pkg/internal/polymorphichelpers/rollback.go
@@ -87,6 +87,9 @@ func (v *RollbackVisitor) VisitAdvancedStatefulSet(kind internalapps.GroupKindEl
 func (v *RollbackVisitor) VisitAdvancedDaemonSet(kind internalapps.GroupKindElement) {
 	v.result = &AdvancedDaemonSetRollbacker{k: v.clientset, kc: v.kruiseclientset}
 }
+func (v *RollbackVisitor) VisitRollout(kind internalapps.GroupKindElement) {
+	v.result = &RolloutRollbacker{k: v.clientset, kc: v.kruiseclientset}
+}
 
 // RollbackerFor returns an implementation of Rollbacker interface for the given schema kind
 func RollbackerFor(kind schema.GroupKind, c kubernetes.Interface, kc kruiseclientsets.Interface) (Rollbacker, error) {
@@ -538,6 +541,20 @@ func (r *AdvancedStatefulSetRollbacker) Rollback(obj runtime.Object,
 type AdvancedDaemonSetRollbacker struct {
 	k  kubernetes.Interface
 	kc kruiseclientsets.Interface
+}
+
+type RolloutRollbacker struct {
+	k  kubernetes.Interface
+	kc kruiseclientsets.Interface
+}
+
+// RolloutRollbacker.Rollback never be called
+func (r *RolloutRollbacker) Rollback(obj runtime.Object,
+	updatedAnnotations map[string]string,
+	toRevision int64,
+	dryRunStrategy cmdutil.DryRunStrategy) (string, error) {
+
+	return rollbackSuccess, nil
 }
 
 func (r *AdvancedDaemonSetRollbacker) Rollback(obj runtime.Object,


### PR DESCRIPTION
1.kubectl-kruise rollout undo命令现在可以支持kruise Rollout作为参数（args），Rollout对象可以作为rollout undo命令的入口，通过Rollout对象的WorkloadRef字段来获取其绑定的workload，然后对workload进行回滚。相比直接对工作负载进行回滚多了一次服务端访问
