### PR TITLE
 Added UnitedDeployment Support for Rollout Restart

### DIFF
--- a/docs/kubectl-kruise_rollout_restart.md
+++ b/docs/kubectl-kruise_rollout_restart.md
@@ -6,7 +6,8 @@ Restart a resource
 
 Restart a resource.
 
-        Resource will be rollout restarted.
+        Resource will be rollout restarted. Supported kinds include:
+        CloneSet, DaemonSet, Deployment, StatefulSet, and UnitedDeployment.
 
 ```
 kubectl-kruise rollout restart RESOURCE
@@ -21,6 +22,9 @@ kubectl-kruise rollout restart RESOURCE
   
   # Restart a daemonset
   kubectl-kruise rollout restart daemonset/abc
+
+  # Restart a UnitedDeployment
+  kubectl-kruise rollout restart uniteddeployment/my-app
 ```
 
 ### Options

--- a/pkg/cmd/rollout/rollout_restart.go
+++ b/pkg/cmd/rollout/rollout_restart.go
@@ -65,7 +65,10 @@ var (
 		kubectl-kruise rollout restart cloneset/abc
 
 		# Restart a daemonset
-		kubectl-kruise rollout restart daemonset/abc`)
+		kubectl-kruise rollout restart daemonset/abc
+
+		# Restart a UnitedDeployment
+		kubectl-kruise rollout restart uniteddeployment/my-app`)
 )
 
 // NewRolloutRestartOptions returns an initialized RestartOptions instance
@@ -80,7 +83,7 @@ func NewRolloutRestartOptions(streams genericclioptions.IOStreams) *RestartOptio
 func NewCmdRolloutRestart(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	o := NewRolloutRestartOptions(streams)
 
-	validArgs := []string{"deployment", "daemonset", "statefulset", "cloneset"}
+	validArgs := []string{"deployment", "daemonset", "statefulset", "cloneset", "uniteddeployment"}
 
 	cmd := &cobra.Command{
 		Use:                   "restart RESOURCE",


### PR DESCRIPTION
This change adds support for the UnitedDeployment workload to the
`kubectl-kruise rollout restart` command.

- It works by adding "uniteddeployment" to the list of valid resource
arguments and updating the command's documentation. The existing
polymorphic restart logic correctly handles the resource by
patching the pod template annotation, so no changes to the core
logic are required.

Fixes #126 