### PR TITLE
Support kubectl‑kruise top cloneset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ bin/
 vendor/
 
 .idea/
+kubectl-kruise

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	k8s.io/component-base v0.30.11
 	k8s.io/klog/v2 v2.120.1
 	k8s.io/kubectl v0.30.11
+	k8s.io/metrics v0.30.11
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/controller-runtime v0.18.6
 	sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3

--- a/go.sum
+++ b/go.sum
@@ -303,6 +303,8 @@ k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 h1:BZqlfIlq5YbRMFko6/PM7F
 k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340/go.mod h1:yD4MZYeKMBwQKVht279WycxKyM84kkAx2DPrTXaeb98=
 k8s.io/kubectl v0.30.11 h1:pBk1AzDpndHl9oBfqJS9J2CGYNyik+x/QanXSERM7gE=
 k8s.io/kubectl v0.30.11/go.mod h1:a8AoybYsyppPEctupfJk4uaSy9uUWdvNfqRmSzbPPCQ=
+k8s.io/metrics v0.30.11 h1:G8+rAXti+TczPzUuHjvqBYTlXbbNYlwMXiapGEZG504=
+k8s.io/metrics v0.30.11/go.mod h1:3FIlGaB4JgsztiWhNTZizba6/ChsHgASe01bTL+zQpM=
 k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSnlTLKgpAAttJvpI=
 k8s.io/utils v0.0.0-20230726121419-3b25d923346b/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/controller-runtime v0.18.6 h1:UnEoLBLDpQwzJ2jYh6aTdiMhGjNDR7IdFn9YEqHIccc=

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -32,6 +32,8 @@ import (
 	krollout "github.com/openkruise/kruise-tools/pkg/cmd/rollout"
 	"github.com/openkruise/kruise-tools/pkg/cmd/scaledown"
 	kset "github.com/openkruise/kruise-tools/pkg/cmd/set"
+	"github.com/openkruise/kruise-tools/pkg/cmd/top"
+	"github.com/openkruise/kruise-tools/pkg/cmd/util"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -382,6 +384,7 @@ func NewKubectlCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 			Message: "Troubleshooting and Debugging Commands:",
 			Commands: []*cobra.Command{
 				cmdexec.NewCmdExec(f, ioStreams),
+				top.NewCmdTop(util.NewFactory(f), ioStreams),
 			},
 		},
 

--- a/pkg/cmd/top/cloneset.go
+++ b/pkg/cmd/top/cloneset.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package top
+
+import (
+	"fmt"
+
+	kruiseappsv1alpha1 "github.com/openkruise/kruise-api/apps/v1alpha1"
+	"github.com/openkruise/kruise-tools/pkg/cmd/util" // <-- Use local factory
+	"github.com/openkruise/kruise-tools/pkg/top"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/i18n"
+)
+
+// TopCloneSetOptions holds the options for the top cloneset command
+type TopCloneSetOptions struct {
+	genericclioptions.IOStreams
+	CloneSetName string
+	Namespace    string
+	Factory      util.Factory // <-- Use local factory interface
+}
+
+// NewCmdTopCloneSet creates the `top cloneset` command.
+func NewCmdTopCloneSet(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command { // <-- Use local factory
+	o := &TopCloneSetOptions{
+		IOStreams: ioStreams,
+		Factory:   f,
+	}
+
+	cmd := &cobra.Command{
+		Use:                   "cloneset NAME",
+		Short:                 i18n.T("Display resource (CPU/Memory) usage of a CloneSet."),
+		Args:                  cobra.ExactArgs(1),
+		DisableFlagsInUseLine: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(o.Complete(cmd, args))
+			cmdutil.CheckErr(o.Run())
+		},
+	}
+
+	// Add namespace flag for user override
+	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", "", "If present, the namespace scope for this CLI request")
+	return cmd
+}
+
+// Complete completes all the required options.
+func (o *TopCloneSetOptions) Complete(cmd *cobra.Command, args []string) error {
+	o.CloneSetName = args[0]
+
+	// The namespace is resolved by the factory's builder, honoring the -n flag
+	var err error
+	o.Namespace, _, err = o.Factory.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return err
+	}
+	// If the user provided a namespace flag, it will be used by the builder later.
+	if cmd.Flags().Changed("namespace") {
+		o.Namespace, _ = cmd.Flags().GetString("namespace")
+	}
+	return nil
+}
+
+// Run executes the `top cloneset` command logic.
+func (o *TopCloneSetOptions) Run() error {
+	// 1. Get the CloneSet object from the server.
+	builder := o.Factory.NewBuilder()
+	result := builder.
+		NamespaceParam(o.Namespace).DefaultNamespace().
+		ResourceNames("cloneset", o.CloneSetName).
+		Do()
+
+	infos, err := result.Infos()
+	if err != nil {
+		return err
+	}
+	if len(infos) != 1 {
+		return fmt.Errorf("expected one CloneSet resource, but found %d", len(infos))
+	}
+	cloneSet, ok := infos[0].Object.(*kruiseappsv1alpha1.CloneSet)
+	if !ok {
+		return fmt.Errorf("unexpected object type: %T, expected *kruiseappsv1alpha1.CloneSet", infos[0].Object)
+	}
+
+	// 2. Get the pod selector for the CloneSet.
+	selector, err := metav1.LabelSelectorAsSelector(cloneSet.Spec.Selector)
+	if err != nil {
+		return fmt.Errorf("could not convert label selector for CloneSet %s: %v", cloneSet.Name, err)
+	}
+
+	// 3. Get the necessary API clients from our local factory.
+	kubeClient, err := o.Factory.KubernetesClientSet()
+	if err != nil {
+		return err
+	}
+	metricsClient, err := o.Factory.MetricsClient()
+	if err != nil {
+		return fmt.Errorf("error getting metrics client: %v. Is the metrics-server installed?", err)
+	}
+
+	// 4. Call the core logic to sum the metrics.
+	totalCPU, totalMemory, err := top.SumUsageForSelector(kubeClient, metricsClient, cloneSet.Namespace, selector)
+	if err != nil {
+		return err
+	}
+
+	// 5. Print the formatted output.
+	cpuString, memoryString := top.FormatResourceUsage(totalCPU, totalMemory)
+	fmt.Fprintf(o.Out, "%-20s\t%-12s\t%-15s\n", "NAME", "CPU(cores)", "MEMORY(bytes)")
+	fmt.Fprintf(o.Out, "%-20s\t%-12s\t%-15s\n", cloneSet.Name, cpuString, memoryString)
+
+	return nil
+}

--- a/pkg/cmd/top/top.go
+++ b/pkg/cmd/top/top.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package top
+
+import (
+	"github.com/openkruise/kruise-tools/pkg/cmd/util" // <-- Use local factory
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+var (
+	topLong = templates.LongDesc(i18n.T(`
+		Display resource (CPU/Memory) usage.
+
+		The top command allows you to see the resource consumption for OpenKruise workloads.`))
+)
+
+// NewCmdTop creates the new parent `top` command.
+func NewCmdTop(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command { // <-- Use local factory
+	cmd := &cobra.Command{
+		Use:   "top",
+		Short: i18n.T("Display resource (CPU/Memory) usage"),
+		Long:  topLong,
+		Run:   cmdutil.DefaultSubCommandRun(ioStreams.ErrOut),
+	}
+
+	// Add subcommands
+	cmd.AddCommand(NewCmdTopCloneSet(f, ioStreams))
+	// In future PRs, you will add other workloads here.
+
+	return cmd
+}

--- a/pkg/cmd/top/top.go
+++ b/pkg/cmd/top/top.go
@@ -17,7 +17,7 @@ limitations under the License.
 package top
 
 import (
-	"github.com/openkruise/kruise-tools/pkg/cmd/util" // <-- Use local factory
+	"github.com/openkruise/kruise-tools/pkg/cmd/util"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -32,8 +32,7 @@ var (
 		The top command allows you to see the resource consumption for OpenKruise workloads.`))
 )
 
-// NewCmdTop creates the new parent `top` command.
-func NewCmdTop(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command { // <-- Use local factory
+func NewCmdTop(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "top",
 		Short: i18n.T("Display resource (CPU/Memory) usage"),
@@ -41,9 +40,6 @@ func NewCmdTop(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra.Com
 		Run:   cmdutil.DefaultSubCommandRun(ioStreams.ErrOut),
 	}
 
-	// Add subcommands
 	cmd.AddCommand(NewCmdTopCloneSet(f, ioStreams))
-	// In future PRs, you will add other workloads here.
-
 	return cmd
 }

--- a/pkg/cmd/util/factory.go
+++ b/pkg/cmd/util/factory.go
@@ -24,6 +24,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/kubectl/pkg/util/openapi"
 	"k8s.io/kubectl/pkg/validation"
+	metricsclientset "k8s.io/metrics/pkg/client/clientset/versioned"
 )
 
 type Factory interface {
@@ -34,6 +35,9 @@ type Factory interface {
 
 	// KubernetesClientSet gives you back an external clientset
 	KubernetesClientSet() (*kubernetes.Clientset, error)
+
+	// MetricsClient gives you back a metrics clientset.
+	MetricsClient() (metricsclientset.Interface, error)
 
 	// RESTClient Returns a RESTClient for accessing Kubernetes resources or an error.
 	RESTClient() (*restclient.RESTClient, error)

--- a/pkg/cmd/util/factory.go
+++ b/pkg/cmd/util/factory.go
@@ -36,7 +36,7 @@ type Factory interface {
 	// KubernetesClientSet gives you back an external clientset
 	KubernetesClientSet() (*kubernetes.Clientset, error)
 
-	// MetricsClient gives you back a metrics clientset.
+	// MetricsClient gives you back a metrics clientset
 	MetricsClient() (metricsclientset.Interface, error)
 
 	// RESTClient Returns a RESTClient for accessing Kubernetes resources or an error.

--- a/pkg/cmd/util/factory_client_access.go
+++ b/pkg/cmd/util/factory_client_access.go
@@ -28,6 +28,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/kubectl/pkg/util/openapi"
+	"k8s.io/kubectl/pkg/validation"
+	metricsclientset "k8s.io/metrics/pkg/client/clientset/versioned"
 )
 
 type factoryImpl struct {
@@ -52,6 +55,27 @@ func (f *factoryImpl) KubernetesClientSet() (*kubernetes.Clientset, error) {
 		return nil, err
 	}
 	return kubernetes.NewForConfig(clientConfig)
+}
+
+func (f *factoryImpl) MetricsClient() (metricsclientset.Interface, error) {
+	clientConfig, err := f.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+	return metricsclientset.NewForConfig(clientConfig)
+}
+
+func (f *factoryImpl) OpenAPIGetter() discovery.OpenAPISchemaInterface {
+	disco, _ := f.clientGetter.ToDiscoveryClient()
+	return openapi.NewOpenAPIGetter(disco)
+}
+
+func (f *factoryImpl) OpenAPISchema() (openapi.Resources, error) {
+	return nil, nil
+}
+
+func (f *factoryImpl) Validator(validate bool) (validation.Schema, error) {
+	return nil, nil
 }
 
 func (f *factoryImpl) DynamicClient() (dynamic.Interface, error) {

--- a/pkg/top/aggregator.go
+++ b/pkg/top/aggregator.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package top
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	metricsclientset "k8s.io/metrics/pkg/client/clientset/versioned"
+)
+
+// SumUsageForSelector sums the resource usage for all pods matching a given selector.
+func SumUsageForSelector(kubeClient kubernetes.Interface, metricsClient metricsclientset.Interface, namespace string, selector labels.Selector) (*resource.Quantity, *resource.Quantity, error) {
+	podList, err := kubeClient.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list pods for selector %q: %v", selector.String(), err)
+	}
+
+	if len(podList.Items) == 0 {
+		return resource.NewMilliQuantity(0, resource.DecimalSI), resource.NewQuantity(0, resource.BinarySI), nil
+	}
+
+	podMetricsList, err := metricsClient.MetricsV1beta1().PodMetricses(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get pod metrics: %v", err)
+	}
+
+	metricsMap := make(map[string]corev1.ResourceList)
+	for _, m := range podMetricsList.Items {
+		totalUsage := corev1.ResourceList{}
+		for _, c := range m.Containers {
+			for resName, resQuant := range c.Usage {
+				if current, ok := totalUsage[resName]; ok {
+					current.Add(resQuant)
+					totalUsage[resName] = current
+				} else {
+					totalUsage[resName] = resQuant
+				}
+			}
+		}
+		metricsMap[m.Name] = totalUsage
+	}
+
+	totalCPU := &resource.Quantity{}
+	totalMemory := &resource.Quantity{}
+	for _, pod := range podList.Items {
+		if metrics, ok := metricsMap[pod.Name]; ok {
+			if cpu, found := metrics[corev1.ResourceCPU]; found {
+				totalCPU.Add(cpu)
+			}
+			if memory, found := metrics[corev1.ResourceMemory]; found {
+				totalMemory.Add(memory)
+			}
+		}
+	}
+
+	return totalCPU, totalMemory, nil
+}
+
+// FormatResourceUsage formats the resource quantities for printing.
+func FormatResourceUsage(cpu *resource.Quantity, memory *resource.Quantity) (string, string) {
+	cpuString := fmt.Sprintf("%vm", cpu.MilliValue())
+	memoryString := fmt.Sprintf("%dMi", memory.Value()/(1024*1024))
+	return cpuString, memoryString
+}


### PR DESCRIPTION
This PR introduces the `top cloneset` command to kubectl‑kruise, allowing users to view aggregated CPU and memory usage for a CloneSet. 

- Adds pkg/top/aggregator.go with pod‑metrics summation logic.  
- Implements pkg/cmd/top/cloneset.go and updates pkg/cmd/top/top.go to register the new subcommand.  
- Extends util.Factory interface for MetricsClient support.  

Fixes #8 