### PR TITLE
Add a "go mod tidy" verification step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,14 @@ jobs:
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
           go-version: ${{ env.GO_VERSION }}
+      - name: Verify go.mod is tidy
+        run: |
+          go mod tidy
+          if [ -n "$(git status --porcelain go.mod go.sum)" ]; then
+            echo "go.mod or go.sum is not tidy"
+            git diff go.mod go.sum
+            exit 1
+          fi
       - name: Cache Go Dependencies
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
@@ -51,6 +59,14 @@ jobs:
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
           go-version: ${{ env.GO_VERSION }}
+      - name: Verify go.mod is tidy
+        run: |
+          go mod tidy
+          if [ -n "$(git status --porcelain go.mod go.sum)" ]; then
+            echo "go.mod or go.sum is not tidy"
+            git diff go.mod go.sum
+            exit 1
+          fi
       - name: Build
         run: |
           make build


### PR DESCRIPTION
## Summary

Added a `go mod tidy` verification step to both CI jobs (`golangci-lint` and `build-and-test`) to ensure that
`go.mod` and `go.sum` are always kept clean and in sync with the code.

## Changes

- After `actions/setup-go` in **both** jobs, run:

  ```bash
  go mod tidy
  if [ -n "$(git status --porcelain go.mod go.sum)" ]; then
    echo "go.mod or go.sum is not tidy"
    git diff go.mod go.sum
    exit 1
  fi
