### PR TITLE
 Add unit tests for sidecar set annotation parsing

### DIFF
--- a/pkg/cmd/util/sidecar_set_test.go
+++ b/pkg/cmd/util/sidecar_set_test.go
@@ -1,0 +1,98 @@
+package util
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetPodHotUpgradeInfoInAnnotations(t *testing.T) {
+	testCases := []struct {
+		name     string
+		pod      *corev1.Pod
+		expected map[string]string
+	}{
+		{
+			name: "Pod with valid hot-upgrade annotation",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						SidecarSetWorkingHotUpgradeContainer: `{"container1":"image-v2"}`,
+					},
+				},
+			},
+			expected: map[string]string{
+				"container1": "image-v2",
+			},
+		},
+		{
+			name: "Pod without hot-upgrade annotation",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"another-annotation": "some-value",
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{
+			name: "Pod with empty annotations",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{
+			name: "Pod with nil annotations",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: nil,
+				},
+			},
+			expected: map[string]string{},
+		},
+		{
+			name: "Pod with invalid JSON in annotation",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						SidecarSetWorkingHotUpgradeContainer: `{"container1":"image-v2"`, // Malformed JSON
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{
+			name: "Pod with empty JSON object in annotation",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						SidecarSetWorkingHotUpgradeContainer: `{}`,
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("Test panicked: %v", r)
+				}
+			}()
+
+			result := GetPodHotUpgradeInfoInAnnotations(tc.pod)
+
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("expected: %v, got: %v", tc.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces comprehensive unit tests for the GetPodHotUpgradeInfoInAnnotations function in `pkg/cmd/util/sidecar_set.go`.

**Reason for Change:**

The GetPodHotUpgradeInfoInAnnotations function contains critical logic for parsing pod annotations, including JSON unmarshalling and handling missing data. Adding unit tests is essential to verify this logic, prevent future regressions, and improve the overall stability of the utility.

**Testing Scenarios Covered:**

The new test suite validates the function's behavior across multiple scenarios:
- A pod with a valid, well-formed JSON annotation.
- A pod that is missing the target annotation.
- A pod with a nil or empty annotations map.
- A pod where the annotation value contains invalid or malformed JSON.

These tests ensure the function is robust and handles both expected and edge-case inputs gracefully.