### PR TITLE
Add support for sonatype nancy vulnerability scanning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.22'
+  GO_VERSION: '1.23'
   GOLANGCI_VERSION: 'v1.55.2'
 
 jobs:
@@ -86,3 +86,38 @@ jobs:
       - name: Test
         run: |
           make test
+
+  security-scan:
+    name: Security Vulnerability Scan
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+
+      - name: Setup Go
+        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Cache Go Dependencies
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
+
+      - name: Generate go.list file for Nancy
+        run: go list -json -deps ./... > go.list
+
+      - name: Run Nancy vulnerability scan
+        uses: sonatype-nexus-community/nancy-github-action@main
+        with:
+          nancyCommand: sleuth
+          goListFile: go.list
+
+      - name: Install and run govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...

--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,0 +1,3 @@
+# Temporary exclusion - proxy/tokenizer vulnerabilities don't affect our usage
+CVE-2025-22870
+CVE-2025-22872

--- a/README.md
+++ b/README.md
@@ -198,6 +198,60 @@ kubectl kruise migrate CloneSet --from Deployment --src-name deployment-demo --d
 #### kubectl kruise autoscale SUBCOMMAND [options]
    * [ ] kubectl kruise autoscale 
 
+## Security
+
+This project includes automated vulnerability scanning to ensure the security of dependencies.
+
+### Vulnerability Scanning
+
+We use two complementary tools to scan for vulnerabilities in our Go dependencies:
+
+1. **Nancy by Sonatype** - Comprehensive dependency scanning against the Sonatype OSS Index
+2. **govulncheck** - Official Go vulnerability scanner with call graph analysis to reduce false positives
+
+### CI/CD Security Integration
+
+Security scans are automatically run:
+- On every push to `master` and `release*` branches
+- On every pull request
+- Daily at 2 AM UTC via scheduled workflow
+
+### Handling Vulnerabilities
+
+If vulnerabilities are found:
+
+1. **Review the vulnerability report** - Check if the vulnerability affects your usage
+2. **Update dependencies** - Upgrade to a non-vulnerable version if available
+3. **Apply workarounds** - If no update is available, consider alternative approaches
+4. **Temporary exclusions** - For false positives or accepted risks, add the CVE ID to `.nancy-ignore`
+
+#### Excluding Vulnerabilities
+
+To exclude specific vulnerabilities from Nancy scans, add the CVE ID or OSS Index ID to the `.nancy-ignore` file:
+
+```
+# Example: Exclude a specific CVE
+CVE-2021-12345
+# Example: Exclude by OSS Index ID
+9eb9a5bc-8310-4104-bf85-3a820d28ba79
+```
+
+### Running Security Scans Locally
+
+To run vulnerability scans locally:
+
+```bash
+# Install tools
+go install github.com/sonatype-nexus-community/nancy@latest
+go install golang.org/x/vuln/cmd/govulncheck@latest
+
+# Run Nancy scan
+go list -json -deps ./... > go.list
+nancy sleuth --loud
+
+# Run govulncheck
+govulncheck ./...
+```
 
 ### Contributing
 We encourage you to help out by reporting issues, improving documentation, fixing bugs, or adding new features. 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/openkruise/kruise-tools
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.4
+toolchain go1.23.4
 
 require (
 	github.com/go-errors/errors v1.4.2


### PR DESCRIPTION
### Which Issue this PR solving?
- Resolves #99

### Changes Made
- Files Modified
  - `.github/workflows/ci.yaml`
  - `.nancy-ignore` (New file)
  - `README.md`
 
### Security Tools Implemented
- Nancy by sonatype
  - Scans all Go dependencie against sonatype OSS Index
  - comprehensive vulnerability database coverage
  - provides detail CVE information and CVSS scores
- govulncheck (official Go tool)
  - uses call graph analysis to reduce false positives
  - only reports vulnerabilities in actually-used code paths
 
### How It Works
- Runs on every push to `master `and `release `branches
- Runs on every pull request
- generates dependency list using go list -json -deps
- scans dependencies with both tools
- fails build if vulnerabilities are found

### Testing Results
- Tested locally on current codebase

<img width="616" height="358" alt="Screenshot 2025-07-14 223502" src="https://github.com/user-attachments/assets/db925494-5a11-4121-b446-434a82a475e3" />

### Why use Nancy + govulncheck Together?
- think of it like this:
  - **Nancy** checks everything , it looks through all your project’s dependencies and flags known vulnerabilities, even the ones you're not using directly.
  - **govulncheck** goes deeper, it checks *your actual code* to see if you’re really using anything dangerous.

### Together, they arre the perfect combo